### PR TITLE
Add a time provider interface to our fetch method.

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -23,8 +23,10 @@ type Fetcher interface {
 	// this.  This function takes as parameters the url we want to get data from,
 	// a user agent string (passed in by the main crawler engine), and an
 	// instantiated http.Client object that the crawler should use to actually
-	// make the request.
-	Fetch(url, userAgent string, client *http.Client) ([]Thing, error)
+	// make the request. We also pass in a TimeProvider which is used internally
+	// by the fetcher to record the indexing time of the parser. This is to allow
+	// for easier testing.
+	Fetch(url, userAgent string, client *http.Client, timeProvider TimeProvider) ([]Thing, error)
 
 	// Host is a function that should return a string containing the host this
 	// fetcher is designed to handle. This should just be the host part and not

--- a/time_provider.go
+++ b/time_provider.go
@@ -1,0 +1,40 @@
+package thingfulx
+
+import (
+	"time"
+)
+
+// TimeProvider is an interface that allows us to test time dependent code
+// easily by providing an implementation of this interface that returns a
+// 'canned' time rather than the real time.
+type TimeProvider interface {
+	// Now returns the current time as seen by the provider. This could be a fake
+	// time for testing time providers.
+	Now() time.Time
+}
+
+// DefaultTimeProvider is an implementation of our TimeProvider interface that
+// returns now directly from time.Now().
+type DefaultTimeProvider struct{}
+
+// Now just returns the time as seen by time.Now()
+func (t *DefaultTimeProvider) Now() time.Time {
+	return time.Now()
+}
+
+// MockTimeProvider is an implementation of the TimeProvider interface that
+// gives back a canned time for all calls to Now(). Intended for use in testing
+// Fetchers.
+type MockTimeProvider struct {
+	internalTime time.Time
+}
+
+// Now returns the internal time of the MockTimeProvider.
+func (t *MockTimeProvider) Now() time.Time {
+	return t.internalTime
+}
+
+// Set is a function that allows setting the internal time of the MockTimeProvider
+func (t *MockTimeProvider) Set(other time.Time) {
+	t.internalTime = other
+}

--- a/time_provider_test.go
+++ b/time_provider_test.go
@@ -1,0 +1,28 @@
+package thingfulx
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMockTimeProvider(t *testing.T) {
+	ts := time.Now()
+
+	provider := MockTimeProvider{ts}
+
+	if provider.Now() != ts {
+		t.Errorf("Unexpected response to Now(), expected '%s', got '%s'", ts, provider.Now())
+	}
+
+	newTs := time.Now()
+
+	provider.Set(newTs)
+
+	if provider.Now() == ts {
+		t.Errorf("Unexpected response to Now(), expected '%s', got '%s'", ts, provider.Now())
+	}
+
+	if provider.Now() != newTs {
+		t.Errorf("Unexpected response to Now(), expected '%s', got '%s'", newTs, provider.Now())
+	}
+}


### PR DESCRIPTION
This is to allow cleaner testing of parsers.