### PR TITLE
Add explicit UID to providers - this should be set to the package name

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -6,6 +6,9 @@ import (
 
 // Provider is a data type used to hold information about a specific upstream data provider.
 type Provider struct {
+	// UID is a unique string identifying the provider. Good practice is to just use the package name
+	UID string
+
 	// Name is the name of the data provider
 	Name string
 


### PR DESCRIPTION
I don't think we can determine this value programmatically at runtime,
so we'll have to be explicit about it.