### PR TITLE
Add FetcherBuilder type definition.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,28 +10,32 @@ GOGET = $(GOCMD) get -u
 
 default: full
 
+.PHONY: setup
 setup:
 	$(GOGET) github.com/alecthomas/$(LINTER)
 	$(LINTER) --install
 
+.PHONY: test
 test:
 	mkdir -p $(ARTEFACT_DIR)
 	$(GOTEST) -coverprofile=$(ARTEFACT_DIR)/cover.out .
 
+.PHONY: coverage
 coverage: test
 	mkdir -p $(ARTEFACT_DIR)
 	$(GOCOVER) -func=$(ARTEFACT_DIR)/cover.out
 
+.PHONY: html
 html: test
 	mkdir -p $(ARTEFACT_DIR)
 	$(GOCOVER) -html=$(ARTEFACT_DIR)/cover.out -o $(ARTEFACT_DIR)/coverage.html
 
+.PHONY: lint
 lint:
 	$(GOLINT) ./...
 
+.PHONY: clean
 clean:
 	rm -rf $(ARTEFACT_DIR)
 
 full: test coverage html lint
-
-.PHONY: setup test lint coverage html clean full

--- a/fetcher.go
+++ b/fetcher.go
@@ -6,6 +6,10 @@ import (
 	"golang.org/x/net/context"
 )
 
+// FetcherBuilder is type definition for the constructor functions that new
+// Fetchers must implement.
+type FetcherBuilder func() (Fetcher, error)
+
 // Fetcher is the main interface for things that know how to fetch some
 // resource from somewhere handling any protocol weirdness or authentication
 // requirements and return back a slice of parsed Thing instances. The


### PR DESCRIPTION
This type defines the constructor function new Fetchers must implement.

This type signature already implemented in Pomelo, but extracting to here to support Dot's test harness