### PR TITLE
This PR ensures tests run across both packages, and enables coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Simple Makefile for building and testing thingfulx
 
+PACKAGES := $(shell go list ./... | grep -v /vendor/ )
 LINTER = gometalinter
 ARTEFACT_DIR = ./build
 GOCMD = go
@@ -18,7 +19,8 @@ setup:
 .PHONY: test
 test:
 	mkdir -p $(ARTEFACT_DIR)
-	$(GOTEST) -coverprofile=$(ARTEFACT_DIR)/cover.out .
+	echo 'mode: count' > $(ARTEFACT_DIR)/cover.out
+	$(foreach package, $(PACKAGES), $(GOTEST) -coverprofile=$(ARTEFACT_DIR)/cover.tmp $(package) && tail -n +2 $(ARTEFACT_DIR)/cover.tmp >> $(ARTEFACT_DIR)/cover.out || exit;)
 
 .PHONY: coverage
 coverage: test


### PR DESCRIPTION
Replicate the shenanigans to enable multipackage coverage to be reported

Previously we were only running the tests in the top level package.