### PR TITLE
add 2 new namespaces and simple data licenses

### DIFF
--- a/dataLicense.go
+++ b/dataLicense.go
@@ -1,0 +1,154 @@
+package thingfulx
+
+// Category is a simple type alias for a string
+
+const (
+
+	// Permissions
+	Reproduction = "https://creativecommons.org/ns#Reproduction"
+	//making multiple copies
+
+	Distribution = "https://creativecommons.org/ns#Distribution"
+	//distribution, public display, and publicly performance
+
+	DerivativeWorks = "https://creativecommons.org/ns#DerivativeWorks"
+	//distribution of derivative works
+
+	Sharing = "https://creativecommons.org/ns#Sharing"
+	// permits commercial derivatives, but only non-commercial distribution
+
+	// Requirements
+	Notice = "https://creativecommons.org/ns#Notice"
+	//copyright and license notices be kept intact
+
+	Attribution = "https://creativecommons.org/ns#Attribution"
+	// credit be given to copyright holder and/or author
+
+	ShareAlike = "https://creativecommons.org/ns#ShareAlike"
+	//derivative works be licensed under the same terms or compatible terms as the original work
+
+	SourceCode = "https://creativecommons.org/ns#SourceCode"
+	// source code (the preferred form for making modifications) must be provided when exercising some rights granted by the license.
+
+	Copyleft = "https://creativecommons.org/ns#Copyleft"
+	//derivative and combined works must be licensed under specified terms, similar to those on the original work
+
+	LesserCopyleft = "https://creativecommons.org/ns#LesserCopyleft"
+	//derivative works must be licensed under specified terms, with at least the same conditions as the original work; combinations with the work may be licensed under different terms
+
+	// Prohibitions
+	CommercialUse = "http://web.resource.org/cc/CommercialUse"
+	// exercising rights for commercial purposes
+
+	HighIncomeNationUse = "https://creativecommons.org/ns#HighIncomeNationUse"
+	//use in a non-developing country
+
+)
+
+type License struct {
+	// Human readable name for this license
+	Name string `json:"name"`
+
+	// url to the short version of the license
+	URL string `json:"id"`
+
+	// url to the long or legal version of the license
+	LegalCodeURL string `json:"legalCodeUrl"`
+
+	Permits []string `json:"permits"`
+
+	Requires []string `json:"requires"`
+
+	Prohibits []string `json:"prohibits"`
+}
+
+var (
+	CC_0_V1 = License{
+
+		Name: "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+
+		URL: "https://creativecommons.org/publicdomain/zero/1.0/",
+
+		LegalCodeURL: "https://creativecommons.org/publicdomain/zero/1.0/legalcode",
+
+		Permits: []string{
+			Reproduction,
+			Distribution,
+			DerivativeWorks,
+			Sharing,
+		},
+
+		Requires: []string{},
+
+		Prohibits: []string{},
+	}
+
+	CC_BY_SA_V4 = License{
+
+		Name: "Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)",
+
+		URL: "https://creativecommons.org/licenses/by-sa/4.0/",
+
+		LegalCodeURL: "https://creativecommons.org/licenses/by-sa/4.0/legalcode",
+
+		Permits: []string{
+			Reproduction,
+			Distribution,
+			DerivativeWorks,
+			Sharing,
+		},
+
+		Requires: []string{
+			Attribution,
+			ShareAlike,
+		},
+
+		Prohibits: []string{},
+	}
+
+	CC_BY_NC_V3 = License{
+
+		Name: "Attribution-NonCommercial 3.0 Unported (CC BY-NC 3.0)",
+
+		URL: "https://creativecommons.org/licenses/by-nc/3.0/",
+
+		LegalCodeURL: "https://creativecommons.org/licenses/by-nc/3.0/legalcode",
+
+		Permits: []string{
+			Reproduction,
+			Distribution,
+			DerivativeWorks,
+			Sharing,
+		},
+
+		Requires: []string{
+			Attribution,
+		},
+
+		Prohibits: []string{
+			CommercialUse,
+		},
+	}
+
+	OGL_V3 = License{
+
+		Name: "open government licence version 3.0",
+
+		URL: "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+
+		LegalCodeURL: "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+
+		Permits: []string{
+			Reproduction,
+			Distribution,
+			DerivativeWorks,
+			Sharing,
+		},
+
+		Requires: []string{
+			Attribution,
+		},
+
+		Prohibits: []string{},
+	}
+)

--- a/dataLicense_test.go
+++ b/dataLicense_test.go
@@ -1,14 +1,18 @@
 package thingfulx
 
 import (
-	// "fmt"
-	"github.com/davecgh/go-spew/spew"
+	"fmt"
+	// "github.com/davecgh/go-spew/spew"
+	"encoding/json"
 	"testing"
 )
 
 func TestLicense(t *testing.T) {
-	spew.Dump(CC_0_V1)
-	spew.Dump(CC_BY_NC_V3)
-	spew.Dump(CC_BY_SA_V4)
-	spew.Dump(OGL_V3)
+	j, _ := json.Marshal(CC_BY_NC_V3)
+	fmt.Println(string(j))
+
+	// spew.Dump(CC_0_V1)
+	// spew.Dump(CC_BY_NC_V3)
+	// spew.Dump(CC_BY_SA_V4)
+	// spew.Dump(OGL_V3)
 }

--- a/dataLicense_test.go
+++ b/dataLicense_test.go
@@ -1,0 +1,14 @@
+package thingfulx
+
+import (
+	// "fmt"
+	"github.com/davecgh/go-spew/spew"
+	"testing"
+)
+
+func TestLicense(t *testing.T) {
+	spew.Dump(CC_0_V1)
+	spew.Dump(CC_BY_NC_V3)
+	spew.Dump(CC_BY_SA_V4)
+	spew.Dump(OGL_V3)
+}

--- a/data_license.go
+++ b/data_license.go
@@ -6,42 +6,42 @@ const (
 
 	// Permissions
 	Reproduction = "https://creativecommons.org/ns#Reproduction"
-	//making multiple copies
+	//Reproduction: making multiple copies
 
 	Distribution = "https://creativecommons.org/ns#Distribution"
-	//distribution, public display, and publicly performance
+	//Distribution: distribution, public display, and publicly performance
 
 	DerivativeWorks = "https://creativecommons.org/ns#DerivativeWorks"
-	//distribution of derivative works
+	//DerivativeWorks: distribution of derivative works
 
 	Sharing = "https://creativecommons.org/ns#Sharing"
-	// permits commercial derivatives, but only non-commercial distribution
+	//Sharing: permits commercial derivatives, but only non-commercial distribution
 
 	// Requirements
 	Notice = "https://creativecommons.org/ns#Notice"
-	//copyright and license notices be kept intact
+	//Notice: copyright and license notices be kept intact
 
 	Attribution = "https://creativecommons.org/ns#Attribution"
-	// credit be given to copyright holder and/or author
+	//Attribution: credit be given to copyright holder and/or author
 
 	ShareAlike = "https://creativecommons.org/ns#ShareAlike"
-	//derivative works be licensed under the same terms or compatible terms as the original work
+	//ShareAlike: derivative works be licensed under the same terms or compatible terms as the original work
 
 	SourceCode = "https://creativecommons.org/ns#SourceCode"
-	// source code (the preferred form for making modifications) must be provided when exercising some rights granted by the license.
+	//SourceCode: source code (the preferred form for making modifications) must be provided when exercising some rights granted by the license.
 
 	Copyleft = "https://creativecommons.org/ns#Copyleft"
-	//derivative and combined works must be licensed under specified terms, similar to those on the original work
+	//Copyleft: derivative and combined works must be licensed under specified terms, similar to those on the original work
 
 	LesserCopyleft = "https://creativecommons.org/ns#LesserCopyleft"
-	//derivative works must be licensed under specified terms, with at least the same conditions as the original work; combinations with the work may be licensed under different terms
+	//LesserCopyleft: derivative works must be licensed under specified terms, with at least the same conditions as the original work; combinations with the work may be licensed under different terms
 
 	// Prohibitions
 	CommercialUse = "http://web.resource.org/cc/CommercialUse"
-	// exercising rights for commercial purposes
+	//CommercialUse: exercising rights for commercial purposes
 
 	HighIncomeNationUse = "https://creativecommons.org/ns#HighIncomeNationUse"
-	//use in a non-developing country
+	//HighIncomeNationUse: use in a non-developing country
 
 )
 

--- a/data_license.go
+++ b/data_license.go
@@ -56,7 +56,7 @@ type DataLicense struct {
 	URL string `json:"id"`
 
 	// url to the long or legal version of the license
-	LegalCodeURL string `json:"legalCodeUrl"`
+	LegalCodeURL string `json:"legalCode"`
 
 	Permits []string `json:"permits"`
 
@@ -106,6 +106,7 @@ var (
 
 		Requires: []string{
 			Attribution,
+			Notice,
 		},
 
 		Prohibits: []string{},
@@ -129,6 +130,7 @@ var (
 
 		Requires: []string{
 			Attribution,
+			Notice,
 			ShareAlike,
 		},
 
@@ -153,6 +155,7 @@ var (
 
 		Requires: []string{
 			Attribution,
+			Notice,
 		},
 
 		Prohibits: []string{
@@ -172,11 +175,11 @@ var (
 		Permits: []string{
 			Reproduction,
 			Distribution,
-			Sharing,
 		},
 
 		Requires: []string{
 			Attribution,
+			Notice,
 		},
 
 		Prohibits: []string{},
@@ -201,6 +204,7 @@ var (
 		Requires: []string{
 			Attribution,
 			ShareAlike,
+			Notice,
 		},
 
 		Prohibits: []string{
@@ -226,6 +230,74 @@ var (
 
 		Requires: []string{
 			Attribution,
+			Notice,
+		},
+
+		Prohibits: []string{},
+	}
+
+	PDDLV1 = DataLicense{
+
+		Name: "Open Data Commons Public Domain Dedication and License (PDDL) v1.0",
+
+		URL: "https://opendatacommons.org/licenses/pddl/1.0/",
+
+		LegalCodeURL: "https://opendatacommons.org/licenses/pddl/1.0/",
+
+		Permits: []string{
+			Reproduction,
+			Distribution,
+			DerivativeWorks,
+			Sharing,
+		},
+
+		Requires: []string{},
+
+		Prohibits: []string{},
+	}
+
+	ODCByV1 = DataLicense{
+
+		Name: "Open Data Commons Attribution License (ODC-By) v1.0",
+
+		URL: "https://opendatacommons.org/licenses/by/1.0/",
+
+		LegalCodeURL: "https://opendatacommons.org/licenses/by/1.0/",
+
+		Permits: []string{
+			Reproduction,
+			Distribution,
+			DerivativeWorks,
+			Sharing,
+		},
+
+		Requires: []string{
+			Attribution,
+			Notice,
+		},
+
+		Prohibits: []string{},
+	}
+
+	ODCODbLV1 = DataLicense{
+
+		Name: "Open Data Commons Open Database License (ODbL) v1.0",
+
+		URL: "https://opendatacommons.org/licenses/odbl/1.0/",
+
+		LegalCodeURL: "https://opendatacommons.org/licenses/odbl/1.0/",
+
+		Permits: []string{
+			Reproduction,
+			Distribution,
+			DerivativeWorks,
+			Sharing,
+		},
+
+		Requires: []string{
+			Attribution,
+			Notice,
+			ShareAlike,
 		},
 
 		Prohibits: []string{},

--- a/data_license.go
+++ b/data_license.go
@@ -44,6 +44,7 @@ const (
 	HighIncomeNationUse = "https://creativecommons.org/ns#HighIncomeNationUse"
 )
 
+// License is struct used to describe data license
 type License struct {
 	// Human readable name for this license
 	Name string `json:"name"`
@@ -62,6 +63,8 @@ type License struct {
 }
 
 var (
+
+	// CC0V1 is a predefined Creative Commons CC0 version 1.0 license
 	CC0V1 = License{
 
 		Name: "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
@@ -82,6 +85,7 @@ var (
 		Prohibits: []string{},
 	}
 
+	// CCByV3 is a predefined Creative Commons CC BY version 3.0 license
 	CCByV3 = License{
 
 		Name: "Attribution 3.0 Unported (CC BY 3.0)",
@@ -104,6 +108,7 @@ var (
 		Prohibits: []string{},
 	}
 
+	// CCBySaV4 is a predefined Creative Commons CC BY-SA version 4.0 license
 	CCBySaV4 = License{
 
 		Name: "Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)",
@@ -127,6 +132,7 @@ var (
 		Prohibits: []string{},
 	}
 
+	// CCByNcV3 is a predefined Creative Commons CC BY-NC version 3.0 license
 	CCByNcV3 = License{
 
 		Name: "Attribution-NonCommercial 3.0 Unported (CC BY-NC 3.0)",
@@ -151,6 +157,7 @@ var (
 		},
 	}
 
+	// CCByNdV3 is a predefined Creative Commons CC BY-ND version 3.0 license
 	CCByNdV3 = License{ // i'm a bit confuse with this one how to describe it, need confirmation with CC
 
 		Name: "Attribution-NoDerivs 3.0 Unported (CC BY-ND 3.0)",
@@ -172,6 +179,7 @@ var (
 		Prohibits: []string{},
 	}
 
+	// CCByNcSaV3 is a predefined Creative Commons CC BY-NC-SA version 3.0 license
 	CCByNcSaV3 = License{
 
 		Name: "Attribution-NonCommercial-ShareAlike 3.0 Unported (CC BY-NC-SA 3.0)",
@@ -197,9 +205,10 @@ var (
 		},
 	}
 
+	// OGLV3 is a predefined Open Government Licence version 3.0 license
 	OGLV3 = License{
 
-		Name: "open government licence version 3.0",
+		Name: "Open Government Licence version 3.0",
 
 		URL: "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
 

--- a/data_license.go
+++ b/data_license.go
@@ -4,7 +4,8 @@ package thingfulx
 
 const (
 
-	// Permissions
+	// Permissions type
+
 	// Reproduction is "making multiple copies"
 	Reproduction = "https://creativecommons.org/ns#Reproduction"
 
@@ -17,7 +18,8 @@ const (
 	// Sharing is "permits commercial derivatives, but only non-commercial distribution"
 	Sharing = "https://creativecommons.org/ns#Sharing"
 
-	// Requirements
+	// Requirements type
+
 	// Notice is "copyright and license notices be kept intact"
 	Notice = "https://creativecommons.org/ns#Notice"
 
@@ -36,7 +38,8 @@ const (
 	// LesserCopyleft is "derivative works must be licensed under specified terms, with at least the same conditions as the original work; combinations with the work may be licensed under different terms"
 	LesserCopyleft = "https://creativecommons.org/ns#LesserCopyleft"
 
-	// Prohibitions
+	// Prohibitions type
+
 	// CommercialUse is "exercising rights for commercial purposes"
 	CommercialUse = "http://web.resource.org/cc/CommercialUse"
 

--- a/data_license.go
+++ b/data_license.go
@@ -6,42 +6,42 @@ const (
 
 	// Permissions
 	Reproduction = "https://creativecommons.org/ns#Reproduction"
-	//Reproduction: making multiple copies
+	//Reproduction refers to "making multiple copies"
 
 	Distribution = "https://creativecommons.org/ns#Distribution"
-	//Distribution: distribution, public display, and publicly performance
+	//Distribution refers to "distribution, public display, and publicly performance"
 
 	DerivativeWorks = "https://creativecommons.org/ns#DerivativeWorks"
-	//DerivativeWorks: distribution of derivative works
+	//DerivativeWorks refers to "distribution of derivative works"
 
 	Sharing = "https://creativecommons.org/ns#Sharing"
-	//Sharing: permits commercial derivatives, but only non-commercial distribution
+	//Sharing refers to "permits commercial derivatives, but only non-commercial distribution"
 
 	// Requirements
 	Notice = "https://creativecommons.org/ns#Notice"
-	//Notice: copyright and license notices be kept intact
+	//Notice refers to "copyright and license notices be kept intact"
 
 	Attribution = "https://creativecommons.org/ns#Attribution"
-	//Attribution: credit be given to copyright holder and/or author
+	//Attribution refers to "credit be given to copyright holder and/or author"
 
 	ShareAlike = "https://creativecommons.org/ns#ShareAlike"
-	//ShareAlike: derivative works be licensed under the same terms or compatible terms as the original work
+	//ShareAlike refers to "derivative works be licensed under the same terms or compatible terms as the original work"
 
 	SourceCode = "https://creativecommons.org/ns#SourceCode"
-	//SourceCode: source code (the preferred form for making modifications) must be provided when exercising some rights granted by the license.
+	//SourceCode refers to "source code (the preferred form for making modifications) must be provided when exercising some rights granted by the license"
 
 	Copyleft = "https://creativecommons.org/ns#Copyleft"
-	//Copyleft: derivative and combined works must be licensed under specified terms, similar to those on the original work
+	//Copyleft refers to "derivative and combined works must be licensed under specified terms, similar to those on the original work"
 
 	LesserCopyleft = "https://creativecommons.org/ns#LesserCopyleft"
-	//LesserCopyleft: derivative works must be licensed under specified terms, with at least the same conditions as the original work; combinations with the work may be licensed under different terms
+	//LesserCopyleft refers to "derivative works must be licensed under specified terms, with at least the same conditions as the original work; combinations with the work may be licensed under different terms"
 
 	// Prohibitions
 	CommercialUse = "http://web.resource.org/cc/CommercialUse"
-	//CommercialUse: exercising rights for commercial purposes
+	//CommercialUse refers to "exercising rights for commercial purposes"
 
 	HighIncomeNationUse = "https://creativecommons.org/ns#HighIncomeNationUse"
-	//HighIncomeNationUse: use in a non-developing country
+	//HighIncomeNationUse refers to "use in a non-developing country"
 
 )
 

--- a/data_license.go
+++ b/data_license.go
@@ -235,7 +235,7 @@ var (
 
 		Prohibits: []string{},
 	}
-
+	// PDDLV1 is a predefined Open Data Commons Public Domain Dedication and License
 	PDDLV1 = DataLicense{
 
 		Name: "Open Data Commons Public Domain Dedication and License (PDDL) v1.0",
@@ -256,6 +256,7 @@ var (
 		Prohibits: []string{},
 	}
 
+	//ODCByV1 is a predefined Open Data Commons Attribution License
 	ODCByV1 = DataLicense{
 
 		Name: "Open Data Commons Attribution License (ODC-By) v1.0",
@@ -279,6 +280,7 @@ var (
 		Prohibits: []string{},
 	}
 
+	//ODCODbLV1 is a predefined Open Data Commons Open Database License
 	ODCODbLV1 = DataLicense{
 
 		Name: "Open Data Commons Open Database License (ODbL) v1.0",

--- a/data_license.go
+++ b/data_license.go
@@ -5,44 +5,43 @@ package thingfulx
 const (
 
 	// Permissions
+	// Reproduction refers to "making multiple copies"
 	Reproduction = "https://creativecommons.org/ns#Reproduction"
-	//Reproduction refers to "making multiple copies"
 
+	// Distribution refers to "distribution, public display, and publicly performance"
 	Distribution = "https://creativecommons.org/ns#Distribution"
-	//Distribution refers to "distribution, public display, and publicly performance"
 
+	// DerivativeWorks refers to "distribution of derivative works"
 	DerivativeWorks = "https://creativecommons.org/ns#DerivativeWorks"
-	//DerivativeWorks refers to "distribution of derivative works"
 
+	// Sharing refers to "permits commercial derivatives, but only non-commercial distribution"
 	Sharing = "https://creativecommons.org/ns#Sharing"
-	//Sharing refers to "permits commercial derivatives, but only non-commercial distribution"
 
 	// Requirements
+	// Notice refers to "copyright and license notices be kept intact"
 	Notice = "https://creativecommons.org/ns#Notice"
-	//Notice refers to "copyright and license notices be kept intact"
 
+	// Attribution refers to "credit be given to copyright holder and/or author"
 	Attribution = "https://creativecommons.org/ns#Attribution"
-	//Attribution refers to "credit be given to copyright holder and/or author"
 
+	// ShareAlike refers to "derivative works be licensed under the same terms or compatible terms as the original work"
 	ShareAlike = "https://creativecommons.org/ns#ShareAlike"
-	//ShareAlike refers to "derivative works be licensed under the same terms or compatible terms as the original work"
 
+	// SourceCode refers to "source code (the preferred form for making modifications) must be provided when exercising some rights granted by the license"
 	SourceCode = "https://creativecommons.org/ns#SourceCode"
-	//SourceCode refers to "source code (the preferred form for making modifications) must be provided when exercising some rights granted by the license"
 
+	// Copyleft refers to "derivative and combined works must be licensed under specified terms, similar to those on the original work"
 	Copyleft = "https://creativecommons.org/ns#Copyleft"
-	//Copyleft refers to "derivative and combined works must be licensed under specified terms, similar to those on the original work"
 
+	// LesserCopyleft refers to "derivative works must be licensed under specified terms, with at least the same conditions as the original work; combinations with the work may be licensed under different terms"
 	LesserCopyleft = "https://creativecommons.org/ns#LesserCopyleft"
-	//LesserCopyleft refers to "derivative works must be licensed under specified terms, with at least the same conditions as the original work; combinations with the work may be licensed under different terms"
 
 	// Prohibitions
+	// CommercialUse refers to "exercising rights for commercial purposes"
 	CommercialUse = "http://web.resource.org/cc/CommercialUse"
-	//CommercialUse refers to "exercising rights for commercial purposes"
 
+	// HighIncomeNationUse refers to "use in a non-developing country"
 	HighIncomeNationUse = "https://creativecommons.org/ns#HighIncomeNationUse"
-	//HighIncomeNationUse refers to "use in a non-developing country"
-
 )
 
 type License struct {

--- a/data_license.go
+++ b/data_license.go
@@ -5,42 +5,42 @@ package thingfulx
 const (
 
 	// Permissions
-	// Reproduction refers to "making multiple copies"
+	// Reproduction is "making multiple copies"
 	Reproduction = "https://creativecommons.org/ns#Reproduction"
 
-	// Distribution refers to "distribution, public display, and publicly performance"
+	// Distribution is "distribution, public display, and publicly performance"
 	Distribution = "https://creativecommons.org/ns#Distribution"
 
-	// DerivativeWorks refers to "distribution of derivative works"
+	// DerivativeWorks is "distribution of derivative works"
 	DerivativeWorks = "https://creativecommons.org/ns#DerivativeWorks"
 
-	// Sharing refers to "permits commercial derivatives, but only non-commercial distribution"
+	// Sharing is "permits commercial derivatives, but only non-commercial distribution"
 	Sharing = "https://creativecommons.org/ns#Sharing"
 
 	// Requirements
-	// Notice refers to "copyright and license notices be kept intact"
+	// Notice is "copyright and license notices be kept intact"
 	Notice = "https://creativecommons.org/ns#Notice"
 
-	// Attribution refers to "credit be given to copyright holder and/or author"
+	// Attribution is "credit be given to copyright holder and/or author"
 	Attribution = "https://creativecommons.org/ns#Attribution"
 
-	// ShareAlike refers to "derivative works be licensed under the same terms or compatible terms as the original work"
+	// ShareAlike is "derivative works be licensed under the same terms or compatible terms as the original work"
 	ShareAlike = "https://creativecommons.org/ns#ShareAlike"
 
-	// SourceCode refers to "source code (the preferred form for making modifications) must be provided when exercising some rights granted by the license"
+	// SourceCode is "source code (the preferred form for making modifications) must be provided when exercising some rights granted by the license"
 	SourceCode = "https://creativecommons.org/ns#SourceCode"
 
-	// Copyleft refers to "derivative and combined works must be licensed under specified terms, similar to those on the original work"
+	// Copyleft is "derivative and combined works must be licensed under specified terms, similar to those on the original work"
 	Copyleft = "https://creativecommons.org/ns#Copyleft"
 
-	// LesserCopyleft refers to "derivative works must be licensed under specified terms, with at least the same conditions as the original work; combinations with the work may be licensed under different terms"
+	// LesserCopyleft is "derivative works must be licensed under specified terms, with at least the same conditions as the original work; combinations with the work may be licensed under different terms"
 	LesserCopyleft = "https://creativecommons.org/ns#LesserCopyleft"
 
 	// Prohibitions
-	// CommercialUse refers to "exercising rights for commercial purposes"
+	// CommercialUse is "exercising rights for commercial purposes"
 	CommercialUse = "http://web.resource.org/cc/CommercialUse"
 
-	// HighIncomeNationUse refers to "use in a non-developing country"
+	// HighIncomeNationUse is "use in a non-developing country"
 	HighIncomeNationUse = "https://creativecommons.org/ns#HighIncomeNationUse"
 )
 

--- a/data_license.go
+++ b/data_license.go
@@ -47,8 +47,8 @@ const (
 	HighIncomeNationUse = "https://creativecommons.org/ns#HighIncomeNationUse"
 )
 
-// License is struct used to describe data license
-type License struct {
+// DataLicense is struct used to describe data license
+type DataLicense struct {
 	// Human readable name for this license
 	Name string `json:"name"`
 
@@ -68,7 +68,7 @@ type License struct {
 var (
 
 	// CC0V1 is a predefined Creative Commons CC0 version 1.0 license
-	CC0V1 = License{
+	CC0V1 = DataLicense{
 
 		Name: "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
 
@@ -89,7 +89,7 @@ var (
 	}
 
 	// CCByV3 is a predefined Creative Commons CC BY version 3.0 license
-	CCByV3 = License{
+	CCByV3 = DataLicense{
 
 		Name: "Attribution 3.0 Unported (CC BY 3.0)",
 
@@ -112,7 +112,7 @@ var (
 	}
 
 	// CCBySaV4 is a predefined Creative Commons CC BY-SA version 4.0 license
-	CCBySaV4 = License{
+	CCBySaV4 = DataLicense{
 
 		Name: "Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)",
 
@@ -136,7 +136,7 @@ var (
 	}
 
 	// CCByNcV3 is a predefined Creative Commons CC BY-NC version 3.0 license
-	CCByNcV3 = License{
+	CCByNcV3 = DataLicense{
 
 		Name: "Attribution-NonCommercial 3.0 Unported (CC BY-NC 3.0)",
 
@@ -161,7 +161,7 @@ var (
 	}
 
 	// CCByNdV3 is a predefined Creative Commons CC BY-ND version 3.0 license
-	CCByNdV3 = License{ // i'm a bit confuse with this one how to describe it, need confirmation with CC
+	CCByNdV3 = DataLicense{ // i'm a bit confuse with this one how to describe it, need confirmation with CC
 
 		Name: "Attribution-NoDerivs 3.0 Unported (CC BY-ND 3.0)",
 
@@ -183,7 +183,7 @@ var (
 	}
 
 	// CCByNcSaV3 is a predefined Creative Commons CC BY-NC-SA version 3.0 license
-	CCByNcSaV3 = License{
+	CCByNcSaV3 = DataLicense{
 
 		Name: "Attribution-NonCommercial-ShareAlike 3.0 Unported (CC BY-NC-SA 3.0)",
 
@@ -209,7 +209,7 @@ var (
 	}
 
 	// OGLV3 is a predefined Open Government Licence version 3.0 license
-	OGLV3 = License{
+	OGLV3 = DataLicense{
 
 		Name: "Open Government Licence version 3.0",
 

--- a/data_license.go
+++ b/data_license.go
@@ -83,6 +83,28 @@ var (
 		Prohibits: []string{},
 	}
 
+	CCByV3 = License{
+
+		Name: "Attribution 3.0 Unported (CC BY 3.0)",
+
+		URL: "https://creativecommons.org/licenses/by/3.0/",
+
+		LegalCodeURL: "https://creativecommons.org/licenses/by/3.0/legalcode",
+
+		Permits: []string{
+			Reproduction,
+			Distribution,
+			DerivativeWorks,
+			Sharing,
+		},
+
+		Requires: []string{
+			Attribution,
+		},
+
+		Prohibits: []string{},
+	}
+
 	CCBySaV4 = License{
 
 		Name: "Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)",
@@ -123,6 +145,52 @@ var (
 
 		Requires: []string{
 			Attribution,
+		},
+
+		Prohibits: []string{
+			CommercialUse,
+		},
+	}
+
+	CCByNdV3 = License{ // i'm a bit confuse with this one how to describe it, need confirmation with CC
+
+		Name: "Attribution-NoDerivs 3.0 Unported (CC BY-ND 3.0)",
+
+		URL: "https://creativecommons.org/licenses/by-nd/3.0/",
+
+		LegalCodeURL: "https://creativecommons.org/licenses/by-nd/3.0/legalcode",
+
+		Permits: []string{
+			Reproduction,
+			Distribution,
+			Sharing,
+		},
+
+		Requires: []string{
+			Attribution,
+		},
+
+		Prohibits: []string{},
+	}
+
+	CCByNcSaV3 = License{
+
+		Name: "Attribution-NonCommercial-ShareAlike 3.0 Unported (CC BY-NC-SA 3.0)",
+
+		URL: "https://creativecommons.org/licenses/by-nc-sa/3.0/",
+
+		LegalCodeURL: "https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode",
+
+		Permits: []string{
+			Reproduction,
+			Distribution,
+			Sharing,
+			DerivativeWorks,
+		},
+
+		Requires: []string{
+			Attribution,
+			ShareAlike,
 		},
 
 		Prohibits: []string{

--- a/data_license.go
+++ b/data_license.go
@@ -63,7 +63,7 @@ type License struct {
 }
 
 var (
-	CC_0_V1 = License{
+	CC0V1 = License{
 
 		Name: "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
 
@@ -83,7 +83,7 @@ var (
 		Prohibits: []string{},
 	}
 
-	CC_BY_SA_V4 = License{
+	CCBySaV4 = License{
 
 		Name: "Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)",
 
@@ -106,7 +106,7 @@ var (
 		Prohibits: []string{},
 	}
 
-	CC_BY_NC_V3 = License{
+	CCByNcV3 = License{
 
 		Name: "Attribution-NonCommercial 3.0 Unported (CC BY-NC 3.0)",
 
@@ -130,7 +130,7 @@ var (
 		},
 	}
 
-	OGL_V3 = License{
+	OGLV3 = License{
 
 		Name: "open government licence version 3.0",
 

--- a/data_license_test.go
+++ b/data_license_test.go
@@ -4,7 +4,38 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+// what should we test?
+// 1. the predefined ones have correct values
+// 2. we can add predefined ones to thing
+// 3. we can add non-predefined ones to thing
+
+func TestCC0(t *testing.T) {
+
+	assert.Equal(t, CC0V1.Name, "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication")
+	assert.Equal(t, CC0V1.URL, "https://creativecommons.org/publicdomain/zero/1.0/")
+	assert.Equal(t, CC0V1.LegalCodeURL, "https://creativecommons.org/publicdomain/zero/1.0/legalcode")
+	// check Permits
+	assert.Contains(t, CC0V1.Permits, Reproduction)
+	assert.Contains(t, CC0V1.Permits, Distribution)
+	assert.Contains(t, CC0V1.Permits, DerivativeWorks)
+	assert.Contains(t, CC0V1.Permits, Sharing)
+
+	// check Requires
+	assert.NotContains(t, CC0V1.Requires, Notice)
+	assert.NotContains(t, CC0V1.Requires, Attribution)
+	assert.NotContains(t, CC0V1.Requires, ShareAlike)
+	assert.NotContains(t, CC0V1.Requires, SourceCode)
+	assert.NotContains(t, CC0V1.Requires, Copyleft)
+	assert.NotContains(t, CC0V1.Requires, LesserCopyleft)
+
+	// check Prohibits
+	assert.NotContains(t, CC0V1.Prohibits, CommercialUse)
+	assert.NotContains(t, CC0V1.Prohibits, HighIncomeNationUse)
+}
 
 func TestLicense(t *testing.T) {
 	j, _ := json.Marshal(CCByNcV3)

--- a/data_license_test.go
+++ b/data_license_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLicense(t *testing.T) {
-	j, _ := json.Marshal(CC_BY_NC_V3)
+	j, _ := json.Marshal(CCByNcV3)
 	fmt.Println(string(j))
 
 	// spew.Dump(CC_0_V1)

--- a/data_license_test.go
+++ b/data_license_test.go
@@ -1,9 +1,8 @@
 package thingfulx
 
 import (
-	"fmt"
-	// "github.com/davecgh/go-spew/spew"
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 

--- a/data_license_test.go
+++ b/data_license_test.go
@@ -2,7 +2,7 @@ package thingfulx
 
 import (
 	// "encoding/json"
-	"fmt"
+	// "fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,50 +15,262 @@ import (
 
 func TestCC0(t *testing.T) {
 
-	assert.Equal(t, CC0V1.Name, "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication")
-	assert.Equal(t, CC0V1.URL, "https://creativecommons.org/publicdomain/zero/1.0/")
-	assert.Equal(t, CC0V1.LegalCodeURL, "https://creativecommons.org/publicdomain/zero/1.0/legalcode")
+	license := CC0V1
+
+	assert.Equal(t, license.Name, "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication")
+	assert.Equal(t, license.URL, "https://creativecommons.org/publicdomain/zero/1.0/")
+	assert.Equal(t, license.LegalCodeURL, "https://creativecommons.org/publicdomain/zero/1.0/legalcode")
 	// check Permits
-	assert.Contains(t, CC0V1.Permits, Reproduction)
-	assert.Contains(t, CC0V1.Permits, Distribution)
-	assert.Contains(t, CC0V1.Permits, DerivativeWorks)
-	assert.Contains(t, CC0V1.Permits, Sharing)
+	assert.Contains(t, license.Permits, Reproduction)
+	assert.Contains(t, license.Permits, Distribution)
+	assert.Contains(t, license.Permits, DerivativeWorks)
+	assert.Contains(t, license.Permits, Sharing)
 
 	// check Requires
-	assert.NotContains(t, CC0V1.Requires, Notice)
-	assert.NotContains(t, CC0V1.Requires, Attribution)
-	assert.NotContains(t, CC0V1.Requires, ShareAlike)
-	assert.NotContains(t, CC0V1.Requires, SourceCode)
-	assert.NotContains(t, CC0V1.Requires, Copyleft)
-	assert.NotContains(t, CC0V1.Requires, LesserCopyleft)
+	assert.NotContains(t, license.Requires, Notice)
+	assert.NotContains(t, license.Requires, Attribution)
+	assert.NotContains(t, license.Requires, ShareAlike)
+	assert.NotContains(t, license.Requires, SourceCode)
+	assert.NotContains(t, license.Requires, Copyleft)
+	assert.NotContains(t, license.Requires, LesserCopyleft)
 
 	// check Prohibits
-	assert.NotContains(t, CC0V1.Prohibits, CommercialUse)
-	assert.NotContains(t, CC0V1.Prohibits, HighIncomeNationUse)
+	assert.NotContains(t, license.Prohibits, CommercialUse)
+	assert.NotContains(t, license.Prohibits, HighIncomeNationUse)
 }
 
-func TestCCCByV3(t *testing.T) {
+func TestCCByV3(t *testing.T) {
 
-	assert.Equal(t, CCByV3.Name, "Attribution 3.0 Unported (CC BY 3.0)")
-	assert.Equal(t, CCByV3.URL, "https://creativecommons.org/licenses/by/3.0/")
-	assert.Equal(t, CCByV3.LegalCodeURL, "https://creativecommons.org/licenses/by/3.0/legalcode")
+	license := CCByV3
+
+	assert.Equal(t, license.Name, "Attribution 3.0 Unported (CC BY 3.0)")
+	assert.Equal(t, license.URL, "https://creativecommons.org/licenses/by/3.0/")
+	assert.Equal(t, license.LegalCodeURL, "https://creativecommons.org/licenses/by/3.0/legalcode")
 	// check Permits
-	assert.Contains(t, CCByV3.Permits, Reproduction)
-	assert.Contains(t, CCByV3.Permits, Distribution)
-	assert.Contains(t, CCByV3.Permits, DerivativeWorks)
-	assert.Contains(t, CCByV3.Permits, Sharing)
+	assert.Contains(t, license.Permits, Reproduction)
+	assert.Contains(t, license.Permits, Distribution)
+	assert.Contains(t, license.Permits, DerivativeWorks)
+	assert.Contains(t, license.Permits, Sharing)
 
 	// check Requires
-	assert.Contains(t, CCByV3.Requires, Attribution)
-	assert.NotContains(t, CCByV3.Requires, Notice)
-	assert.NotContains(t, CCByV3.Requires, ShareAlike)
-	assert.NotContains(t, CCByV3.Requires, SourceCode)
-	assert.NotContains(t, CCByV3.Requires, Copyleft)
-	assert.NotContains(t, CCByV3.Requires, LesserCopyleft)
+	assert.Contains(t, license.Requires, Attribution)
+	assert.Contains(t, license.Requires, Notice)
+	assert.NotContains(t, license.Requires, ShareAlike)
+	assert.NotContains(t, license.Requires, SourceCode)
+	assert.NotContains(t, license.Requires, Copyleft)
+	assert.NotContains(t, license.Requires, LesserCopyleft)
 
 	// check Prohibits
-	assert.NotContains(t, CCByV3.Prohibits, CommercialUse)
-	assert.NotContains(t, CCByV3.Prohibits, HighIncomeNationUse)
+	assert.NotContains(t, license.Prohibits, CommercialUse)
+	assert.NotContains(t, license.Prohibits, HighIncomeNationUse)
+}
+
+func TestCCBySaV3(t *testing.T) {
+
+	license := CCBySaV4
+
+	assert.Equal(t, license.Name, "Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)")
+	assert.Equal(t, license.URL, "https://creativecommons.org/licenses/by-sa/4.0/")
+	assert.Equal(t, license.LegalCodeURL, "https://creativecommons.org/licenses/by-sa/4.0/legalcode")
+	// check Permits
+	assert.Contains(t, license.Permits, Reproduction)
+	assert.Contains(t, license.Permits, Distribution)
+	assert.Contains(t, license.Permits, DerivativeWorks)
+	assert.Contains(t, license.Permits, Sharing)
+
+	// check Requires
+	assert.Contains(t, license.Requires, Attribution)
+	assert.Contains(t, license.Requires, Notice)
+	assert.Contains(t, license.Requires, ShareAlike)
+	assert.NotContains(t, license.Requires, SourceCode)
+	assert.NotContains(t, license.Requires, Copyleft)
+	assert.NotContains(t, license.Requires, LesserCopyleft)
+
+	// check Prohibits
+	assert.NotContains(t, license.Prohibits, CommercialUse)
+	assert.NotContains(t, license.Prohibits, HighIncomeNationUse)
+}
+
+func TestCCByNcV3(t *testing.T) {
+
+	license := CCByNcV3
+
+	assert.Equal(t, license.Name, "Attribution-NonCommercial 3.0 Unported (CC BY-NC 3.0)")
+	assert.Equal(t, license.URL, "https://creativecommons.org/licenses/by-nc/3.0/")
+	assert.Equal(t, license.LegalCodeURL, "https://creativecommons.org/licenses/by-nc/3.0/legalcode")
+	// check Permits
+	assert.Contains(t, license.Permits, Reproduction)
+	assert.Contains(t, license.Permits, Distribution)
+	assert.Contains(t, license.Permits, DerivativeWorks)
+	assert.Contains(t, license.Permits, Sharing)
+
+	// check Requires
+	assert.Contains(t, license.Requires, Attribution)
+	assert.Contains(t, license.Requires, Notice)
+	assert.NotContains(t, license.Requires, ShareAlike)
+	assert.NotContains(t, license.Requires, SourceCode)
+	assert.NotContains(t, license.Requires, Copyleft)
+	assert.NotContains(t, license.Requires, LesserCopyleft)
+
+	// check Prohibits
+	assert.Contains(t, license.Prohibits, CommercialUse)
+	assert.NotContains(t, license.Prohibits, HighIncomeNationUse)
+}
+
+func TestCCByNdV3(t *testing.T) {
+
+	license := CCByNdV3
+
+	assert.Equal(t, license.Name, "Attribution-NoDerivs 3.0 Unported (CC BY-ND 3.0)")
+	assert.Equal(t, license.URL, "https://creativecommons.org/licenses/by-nd/3.0/")
+	assert.Equal(t, license.LegalCodeURL, "https://creativecommons.org/licenses/by-nd/3.0/legalcode")
+	// check Permits
+	assert.Contains(t, license.Permits, Reproduction)
+	assert.Contains(t, license.Permits, Distribution)
+	assert.NotContains(t, license.Permits, DerivativeWorks)
+	assert.NotContains(t, license.Permits, Sharing)
+
+	// check Requires
+	assert.Contains(t, license.Requires, Attribution)
+	assert.Contains(t, license.Requires, Notice)
+	assert.NotContains(t, license.Requires, ShareAlike)
+	assert.NotContains(t, license.Requires, SourceCode)
+	assert.NotContains(t, license.Requires, Copyleft)
+	assert.NotContains(t, license.Requires, LesserCopyleft)
+
+	// check Prohibits
+	assert.NotContains(t, license.Prohibits, CommercialUse)
+	assert.NotContains(t, license.Prohibits, HighIncomeNationUse)
+}
+
+func TestCCByNcSaV3(t *testing.T) {
+
+	license := CCByNcSaV3
+
+	assert.Equal(t, license.Name, "Attribution-NonCommercial-ShareAlike 3.0 Unported (CC BY-NC-SA 3.0)")
+	assert.Equal(t, license.URL, "https://creativecommons.org/licenses/by-nc-sa/3.0/")
+	assert.Equal(t, license.LegalCodeURL, "https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode")
+	// check Permits
+	assert.Contains(t, license.Permits, Reproduction)
+	assert.Contains(t, license.Permits, Distribution)
+	assert.Contains(t, license.Permits, DerivativeWorks)
+	assert.Contains(t, license.Permits, Sharing)
+
+	// check Requires
+	assert.Contains(t, license.Requires, Attribution)
+	assert.Contains(t, license.Requires, Notice)
+	assert.Contains(t, license.Requires, ShareAlike)
+	assert.NotContains(t, license.Requires, SourceCode)
+	assert.NotContains(t, license.Requires, Copyleft)
+	assert.NotContains(t, license.Requires, LesserCopyleft)
+
+	// check Prohibits
+	assert.Contains(t, license.Prohibits, CommercialUse)
+	assert.NotContains(t, license.Prohibits, HighIncomeNationUse)
+}
+
+func TestOGLV3(t *testing.T) {
+
+	license := OGLV3
+
+	assert.Equal(t, license.Name, "Open Government Licence version 3.0")
+	assert.Equal(t, license.URL, "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/")
+	assert.Equal(t, license.LegalCodeURL, "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/")
+	// check Permits
+	assert.Contains(t, license.Permits, Reproduction)
+	assert.Contains(t, license.Permits, Distribution)
+	assert.Contains(t, license.Permits, DerivativeWorks)
+	assert.Contains(t, license.Permits, Sharing)
+
+	// check Requires
+	assert.Contains(t, license.Requires, Attribution)
+	assert.Contains(t, license.Requires, Notice)
+	assert.NotContains(t, license.Requires, ShareAlike)
+	assert.NotContains(t, license.Requires, SourceCode)
+	assert.NotContains(t, license.Requires, Copyleft)
+	assert.NotContains(t, license.Requires, LesserCopyleft)
+
+	// check Prohibits
+	assert.NotContains(t, license.Prohibits, CommercialUse)
+	assert.NotContains(t, license.Prohibits, HighIncomeNationUse)
+}
+
+func TestPDDLV1(t *testing.T) {
+
+	license := PDDLV1
+
+	assert.Equal(t, license.Name, "Open Data Commons Public Domain Dedication and License (PDDL) v1.0")
+	assert.Equal(t, license.URL, "https://opendatacommons.org/licenses/pddl/1.0/")
+	assert.Equal(t, license.LegalCodeURL, "https://opendatacommons.org/licenses/pddl/1.0/")
+	// check Permits
+	assert.Contains(t, license.Permits, Reproduction)
+	assert.Contains(t, license.Permits, Distribution)
+	assert.Contains(t, license.Permits, DerivativeWorks)
+	assert.Contains(t, license.Permits, Sharing)
+
+	// check Requires
+	assert.NotContains(t, license.Requires, Attribution)
+	assert.NotContains(t, license.Requires, Notice)
+	assert.NotContains(t, license.Requires, ShareAlike)
+	assert.NotContains(t, license.Requires, SourceCode)
+	assert.NotContains(t, license.Requires, Copyleft)
+	assert.NotContains(t, license.Requires, LesserCopyleft)
+
+	// check Prohibits
+	assert.NotContains(t, license.Prohibits, CommercialUse)
+	assert.NotContains(t, license.Prohibits, HighIncomeNationUse)
+}
+
+func TestODCByV1(t *testing.T) {
+
+	license := ODCByV1
+
+	assert.Equal(t, license.Name, "Open Data Commons Attribution License (ODC-By) v1.0")
+	assert.Equal(t, license.URL, "https://opendatacommons.org/licenses/by/1.0/")
+	assert.Equal(t, license.LegalCodeURL, "https://opendatacommons.org/licenses/by/1.0/")
+	// check Permits
+	assert.Contains(t, license.Permits, Reproduction)
+	assert.Contains(t, license.Permits, Distribution)
+	assert.Contains(t, license.Permits, DerivativeWorks)
+	assert.Contains(t, license.Permits, Sharing)
+
+	// check Requires
+	assert.Contains(t, license.Requires, Attribution)
+	assert.Contains(t, license.Requires, Notice)
+	assert.NotContains(t, license.Requires, ShareAlike)
+	assert.NotContains(t, license.Requires, SourceCode)
+	assert.NotContains(t, license.Requires, Copyleft)
+	assert.NotContains(t, license.Requires, LesserCopyleft)
+
+	// check Prohibits
+	assert.NotContains(t, license.Prohibits, CommercialUse)
+	assert.NotContains(t, license.Prohibits, HighIncomeNationUse)
+}
+
+func TestODCODbLV1(t *testing.T) {
+
+	license := ODCODbLV1
+
+	assert.Equal(t, license.Name, "Open Data Commons Open Database License (ODbL) v1.0")
+	assert.Equal(t, license.URL, "https://opendatacommons.org/licenses/odbl/1.0/")
+	assert.Equal(t, license.LegalCodeURL, "https://opendatacommons.org/licenses/odbl/1.0/")
+	// check Permits
+	assert.Contains(t, license.Permits, Reproduction)
+	assert.Contains(t, license.Permits, Distribution)
+	assert.Contains(t, license.Permits, DerivativeWorks)
+	assert.Contains(t, license.Permits, Sharing)
+
+	// check Requires
+	assert.Contains(t, license.Requires, Attribution)
+	assert.Contains(t, license.Requires, Notice)
+	assert.Contains(t, license.Requires, ShareAlike)
+	assert.NotContains(t, license.Requires, SourceCode)
+	assert.NotContains(t, license.Requires, Copyleft)
+	assert.NotContains(t, license.Requires, LesserCopyleft)
+
+	// check Prohibits
+	assert.NotContains(t, license.Prohibits, CommercialUse)
+	assert.NotContains(t, license.Prohibits, HighIncomeNationUse)
 }
 
 func TestCustomLicense(t *testing.T) {

--- a/data_license_test.go
+++ b/data_license_test.go
@@ -1,17 +1,10 @@
 package thingfulx
 
 import (
-	// "encoding/json"
-	// "fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-// what should we test?
-// 1. the predefined ones have correct values
-// 2. we can add predefined ones to thing // this is done inside thing_test.go
-// 3. we can add non-predefined ones to thing
 
 func TestCC0(t *testing.T) {
 

--- a/data_license_test.go
+++ b/data_license_test.go
@@ -1,7 +1,7 @@
 package thingfulx
 
 import (
-	"encoding/json"
+	// "encoding/json"
 	"fmt"
 	"testing"
 
@@ -10,7 +10,7 @@ import (
 
 // what should we test?
 // 1. the predefined ones have correct values
-// 2. we can add predefined ones to thing
+// 2. we can add predefined ones to thing // this is done inside thing_test.go
 // 3. we can add non-predefined ones to thing
 
 func TestCC0(t *testing.T) {
@@ -37,12 +37,52 @@ func TestCC0(t *testing.T) {
 	assert.NotContains(t, CC0V1.Prohibits, HighIncomeNationUse)
 }
 
-func TestLicense(t *testing.T) {
-	j, _ := json.Marshal(CCByNcV3)
-	fmt.Println(string(j))
+func TestCCCByV3(t *testing.T) {
 
-	// spew.Dump(CC_0_V1)
-	// spew.Dump(CC_BY_NC_V3)
-	// spew.Dump(CC_BY_SA_V4)
-	// spew.Dump(OGL_V3)
+	assert.Equal(t, CCByV3.Name, "Attribution 3.0 Unported (CC BY 3.0)")
+	assert.Equal(t, CCByV3.URL, "https://creativecommons.org/licenses/by/3.0/")
+	assert.Equal(t, CCByV3.LegalCodeURL, "https://creativecommons.org/licenses/by/3.0/legalcode")
+	// check Permits
+	assert.Contains(t, CCByV3.Permits, Reproduction)
+	assert.Contains(t, CCByV3.Permits, Distribution)
+	assert.Contains(t, CCByV3.Permits, DerivativeWorks)
+	assert.Contains(t, CCByV3.Permits, Sharing)
+
+	// check Requires
+	assert.Contains(t, CCByV3.Requires, Attribution)
+	assert.NotContains(t, CCByV3.Requires, Notice)
+	assert.NotContains(t, CCByV3.Requires, ShareAlike)
+	assert.NotContains(t, CCByV3.Requires, SourceCode)
+	assert.NotContains(t, CCByV3.Requires, Copyleft)
+	assert.NotContains(t, CCByV3.Requires, LesserCopyleft)
+
+	// check Prohibits
+	assert.NotContains(t, CCByV3.Prohibits, CommercialUse)
+	assert.NotContains(t, CCByV3.Prohibits, HighIncomeNationUse)
+}
+
+func TestCustomLicense(t *testing.T) {
+	thing := Thing{
+		Title:       "Title",
+		Description: "Description",
+		DataLicense: DataLicense{
+			Name: "custom made data license",
+			URL:  "http://some/url/to/the/license",
+			Permits: []string{
+				Reproduction,
+				Sharing,
+			},
+			Requires: []string{
+				Attribution,
+			},
+		},
+	}
+
+	assert.Equal(t, thing.DataLicense.Name, "custom made data license")
+	assert.Equal(t, thing.DataLicense.URL, "http://some/url/to/the/license")
+	assert.Contains(t, thing.DataLicense.Permits, Reproduction)
+	assert.Contains(t, thing.DataLicense.Permits, Sharing)
+	assert.Contains(t, thing.DataLicense.Requires, Attribution)
+	assert.NotContains(t, thing.DataLicense.Prohibits, CommercialUse)
+
 }

--- a/schema/namespace.go
+++ b/schema/namespace.go
@@ -22,6 +22,12 @@ const (
 
 	// quSchema is the base url for QU ontologies
 	quSchema = "http://purl.org/NET/ssnx/qu/qu#"
+
+	// schemaOrg is base url for schema.org
+	schemaOrgSchema = "http://schema.org/"
+
+	// ccSchema is base url for Creative Commons REL
+	ccSchema = "https://creativecommons.org/ns#"
 )
 
 var (
@@ -33,6 +39,8 @@ var (
 		"iot-lite:": iotliteSchema,
 		"xsd:":      xsdSchema,
 		"qu:":       quSchema,
+		"schema:":   schemaOrgSchema,
+		"cc:":       ccSchema,
 	}
 )
 

--- a/schema/namespace_test.go
+++ b/schema/namespace_test.go
@@ -41,6 +41,14 @@ func TestExpand(t *testing.T) {
 			expected: "http://purl.org/NET/ssnx/qu/qu#foobar",
 		},
 		{
+			input:    "schema:foobar",
+			expected: "http://schema.org/foobar",
+		},
+		{
+			input:    "cc:foobar",
+			expected: "https://creativecommons.org/ns#foobar",
+		},
+		{
 			input:    "http://purl.org/iot/vocab/thingful#foobar",
 			expected: "http://purl.org/iot/vocab/thingful#foobar",
 		},
@@ -80,7 +88,11 @@ func TestCompact(t *testing.T) {
 		},
 		{
 			input:    "http://schema.org/Organization",
-			expected: "http://schema.org/Organization",
+			expected: "schema:Organization",
+		},
+		{
+			input:    "https://creativecommons.org/ns#license",
+			expected: "cc:license",
 		},
 		{
 			input:    "http://purl.org/NET/ssnx/qu/qu#foobar",

--- a/thing.go
+++ b/thing.go
@@ -53,10 +53,18 @@ type Thing struct {
 	// The value will be those defined by m3-lite's domain of interest, plus some additionally defined by thingful
 	Category string `json:"category"`
 
-	// DataLicense indicates what of data license this thing has, it is short for thingful:hasDataLicense
+	// DataLicense indicates what of data license this thing has, it is short for cc:license
 	// This could be used to decide what can we do with this thing's data
-	// NOTE: need data license ontology!!
-	DataLicense string `json:"dataLicense"`
+	// It takes DataLicense struct which can be manually defined or use predefined ones
+	DataLicense DataLicense `json:"license"`
+
+	// AttributionName indicates name ot the author of the data (if required)
+	// it is short for cc:attributionName
+	AttributionName string `json:"attributionName,omitempty"`
+
+	// AttributionURL indicates name ot the author of the data (if required)
+	// it is short for cc:attributionURL
+	AttributionURL string `json:"attributionURL,omitempty"`
 }
 
 // Provider is a data structure containing information about the upstream

--- a/thing.go
+++ b/thing.go
@@ -65,6 +65,9 @@ type Thing struct {
 	// AttributionURL indicates name ot the author of the data (if required)
 	// it is short for cc:attributionURL
 	AttributionURL string `json:"attributionURL,omitempty"`
+
+	// UpdateInterval indicates how often this resource should get updated (in seconds)
+	UpdateInterval int `json:"updateInterval,omitempty"`
 }
 
 // Provider is a data structure containing information about the upstream

--- a/thing_test.go
+++ b/thing_test.go
@@ -33,9 +33,11 @@ func TestCompleteThing(t *testing.T) {
 			Description: "Test Provider description",
 			URL:         "http://example.com",
 		},
-		ThingType:   schema.Expand("thingful:ConnectedDevice"),
-		DataLicense: schema.Expand("thingful:SomeRandomDataLicense"),
-		Category:    Environment.Name,
+		ThingType:       schema.Expand("thingful:ConnectedDevice"),
+		DataLicense:     CCByV3,
+		AttributionName: "Test Data Author",
+		AttributionURL:  "http://some/data/author/url",
+		Category:        Environment.Name,
 		Metadata: []Metadata{
 			{
 				Prop: schema.HasCategory,
@@ -91,7 +93,9 @@ func TestCompleteThing(t *testing.T) {
 	assert.Equal(t, thing.Provider.Description, "Test Provider description")
 	assert.Equal(t, thing.Provider.URL, "http://example.com")
 	assert.Equal(t, thing.ThingType, schema.Expand("thingful:ConnectedDevice"))
-	assert.Equal(t, thing.DataLicense, schema.Expand("thingful:SomeRandomDataLicense"))
+	assert.Equal(t, thing.DataLicense, CCByV3)
+	assert.Equal(t, thing.AttributionName, "Test Data Author")
+	assert.Equal(t, thing.AttributionURL, "http://some/data/author/url")
 	assert.Equal(t, thing.Category, Environment.Name)
 	assert.Equal(t, thing.Metadata[0].Prop, schema.HasCategory)
 	assert.Equal(t, thing.Metadata[0].Val, "Environment")

--- a/thing_test.go
+++ b/thing_test.go
@@ -38,6 +38,7 @@ func TestCompleteThing(t *testing.T) {
 		AttributionName: "Test Data Author",
 		AttributionURL:  "http://some/data/author/url",
 		Category:        Environment.Name,
+		UpdateInterval:  900,
 		Metadata: []Metadata{
 			{
 				Prop: schema.HasCategory,
@@ -97,6 +98,7 @@ func TestCompleteThing(t *testing.T) {
 	assert.Equal(t, thing.AttributionName, "Test Data Author")
 	assert.Equal(t, thing.AttributionURL, "http://some/data/author/url")
 	assert.Equal(t, thing.Category, Environment.Name)
+	assert.Equal(t, thing.UpdateInterval, 900)
 	assert.Equal(t, thing.Metadata[0].Prop, schema.HasCategory)
 	assert.Equal(t, thing.Metadata[0].Val, "Environment")
 	assert.Len(t, thing.Channels, 1)


### PR DESCRIPTION
this License struct produces JSON that looks like this
```
{
  "name": "Attribution-NonCommercial 3.0 Unported (CC BY-NC 3.0)",
  "id": "https://creativecommons.org/licenses/by-nc/3.0/",
  "legalCodeUrl": "https://creativecommons.org/licenses/by-nc/3.0/legalcode",
  "permits": [
    "https://creativecommons.org/ns#Reproduction",
    "https://creativecommons.org/ns#Distribution",
    "https://creativecommons.org/ns#DerivativeWorks",
    "https://creativecommons.org/ns#Sharing"
  ],
  "requires": [
    "https://creativecommons.org/ns#Attribution"
  ],
  "prohibits": [
    "http://web.resource.org/cc/CommercialUse"
  ]
}
```

* update Thing struct to accept DataLicense type
* add Thing struct UpdateInterval field
* add test cases for DataLicense