### PR TITLE
Add serialize helper function that performs our string serialization

### DIFF
--- a/schema/data_type.go
+++ b/schema/data_type.go
@@ -1,5 +1,11 @@
 package schema
 
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
 // DataType is a type alias used for describing the type of an observation's
 // value
 type DataType string
@@ -22,4 +28,50 @@ const (
 
 	// BytesType is our exported const representing an opaque slice of bytes
 	BytesType = DataType("http://www.w3.org/2001/XMLSchema#bytes")
+
+	// XSDTimeFormat is our time format string used for XSD time instances
+	XSDTimeFormat = "15:04:05"
 )
+
+// Serialize is our helper function that serializes a value of one of the above
+// types into a string serialization we return to pomelo.
+func Serialize(value interface{}, dataType DataType) (string, error) {
+	switch dataType {
+	case IntegerType:
+		v, ok := value.(int)
+		if !ok {
+			return "", fmt.Errorf("cannot type assert value '%v' to int", value)
+		}
+		return strconv.Itoa(v), nil
+	case DoubleType:
+		v, ok := value.(float64)
+		if !ok {
+			return "", fmt.Errorf("cannot type assert value '%v' to float64", value)
+		}
+		return strconv.FormatFloat(v, 'g', -1, 64), nil
+	case DateTimeType:
+		v, ok := value.(time.Time)
+		if !ok {
+			return "", fmt.Errorf("cannot type assert value '%v' to time.Time", value)
+		}
+		return v.Format(time.RFC3339Nano), nil
+	case TimeType:
+		v, ok := value.(time.Time)
+		if !ok {
+			return "", fmt.Errorf("cannot type assert value '%v' to time.Time", value)
+		}
+		return v.Format(XSDTimeFormat), nil
+	case BytesType:
+		v, ok := value.([]byte)
+		if !ok {
+			return "", fmt.Errorf("cannot type assert value '%v' to []byte", value)
+		}
+		return string(v), nil
+	default:
+		v, ok := value.(string)
+		if !ok {
+			return "", fmt.Errorf("cannot type assert value '%v' to string", value)
+		}
+		return v, nil
+	}
+}

--- a/schema/data_type.go
+++ b/schema/data_type.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"time"
@@ -28,6 +29,10 @@ const (
 
 	// BytesType is our exported const representing an opaque slice of bytes
 	BytesType = DataType("http://www.w3.org/2001/XMLSchema#bytes")
+
+	// DateTimeList is our exported const representing a value that is a comma
+	// separated list of dateTime instances. Used for transport data values.
+	TimeListType = DataType("http://purl.org/iot/vocab/thingful#timeList")
 
 	// XSDTimeFormat is our time format string used for XSD time instances
 	XSDTimeFormat = "15:04:05"
@@ -67,6 +72,21 @@ func Serialize(value interface{}, dataType DataType) (string, error) {
 			return "", fmt.Errorf("cannot type assert value '%v' to []byte", value)
 		}
 		return string(v), nil
+	case TimeListType:
+		v, ok := value.([]time.Time)
+		if !ok {
+			return "", fmt.Errorf("cannot type assert value '%v' to []time.Time", value)
+		}
+
+		var buf bytes.Buffer
+		for i, t := range v {
+			buf.WriteString(t.Format(XSDTimeFormat))
+			if i < (len(v) - 1) {
+				buf.WriteString(",")
+			}
+		}
+
+		return buf.String(), nil
 	default:
 		v, ok := value.(string)
 		if !ok {

--- a/schema/data_type.go
+++ b/schema/data_type.go
@@ -30,7 +30,7 @@ const (
 	// BytesType is our exported const representing an opaque slice of bytes
 	BytesType = DataType("http://www.w3.org/2001/XMLSchema#bytes")
 
-	// DateTimeList is our exported const representing a value that is a comma
+	// TimeListType is our exported const representing a value that is a comma
 	// separated list of dateTime instances. Used for transport data values.
 	TimeListType = DataType("http://purl.org/iot/vocab/thingful#timeList")
 

--- a/schema/data_type_test.go
+++ b/schema/data_type_test.go
@@ -1,0 +1,103 @@
+package schema
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSerializeValid(t *testing.T) {
+	testcases := []struct {
+		value    interface{}
+		dataType DataType
+		expected string
+	}{
+		{
+			23.2,
+			DoubleType,
+			"23.2",
+		},
+		{
+			23.0,
+			DoubleType,
+			"23",
+		},
+		{
+			23,
+			IntegerType,
+			"23",
+		},
+		{
+			time.Date(2017, 6, 1, 10, 10, 0, 0, time.UTC),
+			DateTimeType,
+			"2017-06-01T10:10:00Z",
+		},
+		{
+			time.Date(2017, 6, 1, 10, 10, 0, 0, time.UTC),
+			TimeType,
+			"10:10:00",
+		},
+		{
+			[]byte("foo"),
+			BytesType,
+			"foo",
+		},
+		{
+			"foo",
+			StringType,
+			"foo",
+		},
+	}
+
+	for _, testcase := range testcases {
+		got, err := Serialize(testcase.value, testcase.dataType)
+		assert.Nil(t, err)
+		assert.Equal(t, testcase.expected, got)
+	}
+}
+
+func TestSerializeInvalid(t *testing.T) {
+	testcases := []struct {
+		value    interface{}
+		dataType DataType
+		message  string
+	}{
+		{
+			"foo",
+			IntegerType,
+			"cannot type assert value 'foo' to int",
+		},
+		{
+			"foo",
+			DoubleType,
+			"cannot type assert value 'foo' to float64",
+		},
+		{
+			"foo",
+			DateTimeType,
+			"cannot type assert value 'foo' to time.Time",
+		},
+		{
+			"foo",
+			TimeType,
+			"cannot type assert value 'foo' to time.Time",
+		},
+		{
+			"foo",
+			BytesType,
+			"cannot type assert value 'foo' to []byte",
+		},
+		{
+			123,
+			StringType,
+			"cannot type assert value '123' to string",
+		},
+	}
+
+	for _, testcase := range testcases {
+		_, err := Serialize(testcase.value, testcase.dataType)
+		assert.NotNil(t, err)
+		assert.Equal(t, testcase.message, err.Error())
+	}
+}

--- a/schema/data_type_test.go
+++ b/schema/data_type_test.go
@@ -48,6 +48,27 @@ func TestSerializeValid(t *testing.T) {
 			StringType,
 			"foo",
 		},
+		{
+			[]time.Time{
+				time.Date(2017, 6, 1, 10, 10, 0, 0, time.UTC),
+			},
+			TimeListType,
+			"10:10:00",
+		},
+		{
+			[]time.Time{
+				time.Date(2017, 6, 1, 10, 10, 0, 0, time.UTC),
+				time.Date(2017, 6, 1, 10, 15, 0, 0, time.UTC),
+				time.Date(2017, 6, 1, 10, 20, 0, 0, time.UTC),
+			},
+			TimeListType,
+			"10:10:00,10:15:00,10:20:00",
+		},
+		{
+			[]time.Time{},
+			TimeListType,
+			"",
+		},
 	}
 
 	for _, testcase := range testcases {
@@ -92,6 +113,11 @@ func TestSerializeInvalid(t *testing.T) {
 			123,
 			StringType,
 			"cannot type assert value '123' to string",
+		},
+		{
+			"foo",
+			TimeListType,
+			"cannot type assert value 'foo' to []time.Time",
 		},
 	}
 


### PR DESCRIPTION
We do not want the case where individual fetchers are serializing values
themselves, so create this function to do that in a consistent way.

Also relates to TD-149