### PR TITLE
shorten location json  tags 

### DIFF
--- a/location.go
+++ b/location.go
@@ -3,7 +3,7 @@ package thingfulx
 // Location is a data structure which holds an individual Thing or Observations
 // geographic coordinates
 type Location struct {
-	Lng       float64 `json:"longitude"`
-	Lat       float64 `json:"latitude"`
+	Lng       float64 `json:"long"`
+	Lat       float64 `json:"lat"`
 	Elevation float64 `json:"elevation,omitempty"`
 }


### PR DESCRIPTION
This tiny PR renames location json tags according to the existing [open-api specs ](https://thingful.github.io/openapi-spec)