### PR TITLE
Json omit empty

### DIFF
--- a/data_license.go
+++ b/data_license.go
@@ -104,16 +104,16 @@ type DataLicense struct {
 	URL string `json:"id"`
 
 	// url to the long or legal version of the license
-	LegalCodeURL string `json:"legalCode"`
+	LegalCodeURL string `json:"legalCode,omitempty"`
 
 	// array containing list of properties that this license permits
-	Permits []string `json:"permits"`
+	Permits []string `json:"permits,omitempty"`
 
 	// array containing list of properties that this license requires
-	Requires []string `json:"requires"`
+	Requires []string `json:"requires,omitempty"`
 
 	// array containing list of properties that this license prohibits
-	Prohibits []string `json:"prohibits"`
+	Prohibits []string `json:"prohibits,omitempty"`
 }
 
 var (

--- a/metadata.go
+++ b/metadata.go
@@ -8,6 +8,6 @@ package thingfulx
 // thingful.net map.  The Metadata object must also contain information about
 // the data visibility - see http://theodi.org/data-spectrum for more info.
 type Metadata struct {
-	Prop string `json:"property"`
-	Val  string `json:"value"`
+	Prop string `json:"prop"`
+	Val  string `json:"val"`
 }

--- a/thing.go
+++ b/thing.go
@@ -78,7 +78,7 @@ type Thing struct {
 type Provider struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 	URL         string `json:"url"`
 }
 


### PR DESCRIPTION
Another tiny PR that adds few `omitempty` json flags to prevent from rendering various optional properties in case they are `nil`.