### PR TITLE
change to new address

### DIFF
--- a/data_license.go
+++ b/data_license.go
@@ -44,7 +44,7 @@ const (
 	// Prohibitions type
 
 	// CommercialUse is "exercising rights for commercial purposes"
-	CommercialUse = "http://web.resource.org/cc/CommercialUse"
+	CommercialUse = "https://creativecommons.org/ns#CommercialUse"
 
 	// HighIncomeNationUse is "use in a non-developing country"
 	HighIncomeNationUse = "https://creativecommons.org/ns#HighIncomeNationUse"


### PR DESCRIPTION
`cc:CoomercialUse` has been using old url, `http://web.resource.org/cc/` changing it to current one `https://creativecommons.org/ns#`