### PR TITLE
add 2 new namespaces and fix string contains bug

### DIFF
--- a/schema/namespace.go
+++ b/schema/namespace.go
@@ -28,19 +28,27 @@ const (
 
 	// ccSchema is base url for Creative Commons REL
 	ccSchema = "https://creativecommons.org/ns#"
+
+	// ccSchema is base url for Creative Commons REL
+	jsonapiSchema = "http://purl.org/iot/vocab/jsonapi#"
+
+	// ccSchema is base url for Creative Commons REL
+	thingfulQuSchema = "http://purl.org/iot/vocab/thingful/qu#"
 )
 
 var (
 	// expanded is a map containing the schema to compact form mappings.
 	namespaces = map[string]string{
-		"thingful:": thingfulSchema,
-		"m3-lite:":  m3liteSchema,
-		"ssn:":      ssnSchema,
-		"iot-lite:": iotliteSchema,
-		"xsd:":      xsdSchema,
-		"qu:":       quSchema,
-		"schema:":   schemaOrgSchema,
-		"cc:":       ccSchema,
+		"thingful:":   thingfulSchema,
+		"m3-lite:":    m3liteSchema,
+		"ssn:":        ssnSchema,
+		"iot-lite:":   iotliteSchema,
+		"xsd:":        xsdSchema,
+		"qu:":         quSchema,
+		"schema:":     schemaOrgSchema,
+		"cc:":         ccSchema,
+		"jsonapi:":    jsonapiSchema,
+		"thingfulqu:": thingfulQuSchema,
 	}
 )
 
@@ -50,7 +58,7 @@ var (
 func Expand(val string) string {
 	// k is the compact version, v is the expanded, and val is a compact string
 	for k, v := range namespaces {
-		if strings.Contains(val, k) {
+		if strings.HasPrefix(val, k) {
 			return strings.Replace(val, k, v, 1)
 		}
 	}
@@ -65,7 +73,7 @@ func Expand(val string) string {
 func Compact(val string) string {
 	// here k is still the compact, v is the expanded, but val is the expanded string
 	for k, v := range namespaces {
-		if strings.Contains(val, v) {
+		if strings.HasPrefix(val, v) {
 			return strings.Replace(val, v, k, 1)
 		}
 	}

--- a/schema/namespace_test.go
+++ b/schema/namespace_test.go
@@ -45,6 +45,14 @@ func TestExpand(t *testing.T) {
 			expected: "http://schema.org/foobar",
 		},
 		{
+			input:    "jsonapi:foobar",
+			expected: "http://purl.org/iot/vocab/jsonapi#foobar",
+		},
+		{
+			input:    "thingfulqu:foobar1",
+			expected: "http://purl.org/iot/vocab/thingful/qu#foobar1",
+		},
+		{
 			input:    "cc:foobar",
 			expected: "https://creativecommons.org/ns#foobar",
 		},
@@ -97,6 +105,14 @@ func TestCompact(t *testing.T) {
 		{
 			input:    "http://purl.org/NET/ssnx/qu/qu#foobar",
 			expected: "qu:foobar",
+		},
+		{
+			input:    "http://purl.org/iot/vocab/thingful/qu#foobar",
+			expected: "thingfulqu:foobar",
+		},
+		{
+			input:    "http://purl.org/iot/vocab/jsonapi#foobar",
+			expected: "jsonapi:foobar",
 		},
 		{
 			input:    "m3-lite:foobar",


### PR DESCRIPTION
* add `jsonapi` namespace
* add `thingfulqu` namespace
* `strings.Contains()` create bug when one namespaces contains another
    * eg; `thingfulqu` contains `qu`
* this is fixed by using `strings.HasPrefix()` instead