### PR TITLE
add namespace for Simple Event Model ontology

### DIFF
--- a/schema/namespace.go
+++ b/schema/namespace.go
@@ -41,11 +41,15 @@ const (
 	// datexSchema is base url for Datex2 schema, it is the domain for Traffic & Transport
 	datexSchema = "http://vocab.datex.org/terms#"
 
-	//mobivocSchema is base url for Mobivoc schema, it is the domain for Mobility
+	// mobivocSchema is base url for Mobivoc schema, it is the domain for Mobility
 	mobivocSchema = "http://schema.mobivoc.org/"
 
-	//siriSchema is base url for unofficial SIRI (Service Interface for Real Time Information) ontology
+	// siriSchema is base url for unofficial SIRI (Service Interface for Real Time Information) ontology
 	siriSchema = "http://purl.org/iot/vocab/siri#"
+
+	// semSchema is the base url for the Simple Event Model ontology, used to
+	// describe the events in various subject domains.
+	semSchema = "http://semanticweb.cs.vu.nl/2009/11/sem/"
 )
 
 var (
@@ -65,6 +69,7 @@ var (
 		"datex:":      datexSchema,
 		"mobivoc:":    mobivocSchema,
 		"siri:":       siriSchema,
+		"sem":         semSchema,
 	}
 )
 

--- a/schema/namespace.go
+++ b/schema/namespace.go
@@ -48,7 +48,7 @@ const (
 	siriSchema = "http://purl.org/iot/vocab/siri#"
 
 	// semSchema is the base url for the Simple Event Model ontology, used to
-	// describe the events in various subject domains.
+	// describe events in various subject domains.
 	semSchema = "http://semanticweb.cs.vu.nl/2009/11/sem/"
 )
 
@@ -69,7 +69,7 @@ var (
 		"datex:":      datexSchema,
 		"mobivoc:":    mobivocSchema,
 		"siri:":       siriSchema,
-		"sem":         semSchema,
+		"sem:":        semSchema,
 	}
 )
 

--- a/schema/namespace_test.go
+++ b/schema/namespace_test.go
@@ -76,6 +76,10 @@ func TestExpand(t *testing.T) {
 			input:    "http://purl.org/iot/vocab/thingful#foobar",
 			expected: "http://purl.org/iot/vocab/thingful#foobar",
 		},
+		{
+			input:    "moc:foobar",
+			expected: "http://semanticweb.cs.vu.nl/2009/11/sem/foobar",
+		},
 	}
 
 	for _, testcase := range testcases {
@@ -149,6 +153,10 @@ func TestCompact(t *testing.T) {
 		{
 			input:    "m3-lite:foobar",
 			expected: "m3-lite:foobar",
+		},
+		{
+			input:    "http://semanticweb.cs.vu.nl/2009/11/sem/foobar",
+			expected: "sem:foobar",
 		},
 	}
 

--- a/schema/namespace_test.go
+++ b/schema/namespace_test.go
@@ -77,7 +77,7 @@ func TestExpand(t *testing.T) {
 			expected: "http://purl.org/iot/vocab/thingful#foobar",
 		},
 		{
-			input:    "moc:foobar",
+			input:    "sem:foobar",
 			expected: "http://semanticweb.cs.vu.nl/2009/11/sem/foobar",
 		},
 	}


### PR DESCRIPTION
This PR adds a new ontology namespace to the list of known schemas: http://semanticweb.cs.vu.nl/2009/11/sem/semdoc.html.

This Ontology can be used for "modeling time and place aspects of a domain. In addition, events provide a way to describe complicated relations between people, places, actions and objects."