### PR TITLE
Add new mock clock constructor that takes no parameter

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -28,9 +28,17 @@ func (c DefaultClock) Now() time.Time {
 	return time.Now()
 }
 
-// NewMockClock is a convenience helper that returns a new
-// MockClock initialized to the specified time.
-func NewMockClock(t time.Time) Clock {
+// NewMockClock returns a new MockClock with the internal time set to the time
+// at which the method was invoked.
+func NewMockClock() Clock {
+	return &MockClock{
+		internalTime: time.Now(),
+	}
+}
+
+// NewMockClockAt returns a new MockClock initialized to the passed in time
+// variable.
+func NewMockClockAt(t time.Time) Clock {
 	return &MockClock{
 		internalTime: t,
 	}

--- a/clock_test.go
+++ b/clock_test.go
@@ -8,15 +8,22 @@ import (
 )
 
 func TestClock(t *testing.T) {
-	provider := NewClock()
+	clock := NewClock()
 
-	provider.Now()
+	clock.Now()
+}
+
+func TestMockClockAt(t *testing.T) {
+	ts := time.Now()
+
+	clock := NewMockClockAt(ts)
+
+	assert.Equal(t, clock.Now(), ts)
 }
 
 func TestMockClock(t *testing.T) {
-	ts := time.Now()
-
-	provider := NewMockClock(ts)
-
-	assert.Equal(t, provider.Now(), ts)
+	clock := NewMockClock()
+	ts := clock.Now()
+	assert.NotNil(t, ts)
+	assert.Equal(t, ts, clock.Now())
 }


### PR DESCRIPTION
This is for all the cases where we don't care about the now value or
mock clock returns because the function we are passing it to doesn't use
it.